### PR TITLE
修改内容

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 bower_components
 js/dist
 composer.lock
+.idea


### PR DESCRIPTION
1. 因点赞等其他操作导致帖子重复进入小黑屋的BUG
2. 开启无命中自动通过小黑屋功能后导致全局敏感词失效的BUG
3. 因帖子标题中有敏感词导致下面所有评论都无法通过修改退出小黑屋的问题